### PR TITLE
fix #78, handle permissions for docker.sock in a better way

### DIFF
--- a/build/gitkubed/sshd_config
+++ b/build/gitkubed/sshd_config
@@ -15,10 +15,6 @@ HostKey /etc/ssh/ssh_host_ed25519_key
 #Privilege Separation is turned on for security
 UsePrivilegeSeparation yes
 
-# Lifetime and size of ephemeral version 1 server key
-KeyRegenerationInterval 3600
-ServerKeyBits 1024
-
 # Logging
 SyslogFacility AUTH
 LogLevel INFO
@@ -28,14 +24,11 @@ LoginGraceTime 120
 PermitRootLogin No
 StrictModes yes
 
-RSAAuthentication yes
 PubkeyAuthentication yes
 #AuthorizedKeysFile	%h/.ssh/authorized_keys
 
 # Don't read the user's ~/.rhosts and ~/.shosts files
 IgnoreRhosts yes
-# For this to work you will also need host keys in /etc/ssh_known_hosts
-RhostsRSAAuthentication no
 # similar for protocol version 2
 HostbasedAuthentication no
 # Uncomment if you don't trust ~/.ssh/known_hosts for RhostsRSAAuthentication

--- a/build/gitkubed/sshd_config
+++ b/build/gitkubed/sshd_config
@@ -9,7 +9,7 @@ Port 22
 Protocol 2
 # HostKeys for protocol version 2
 HostKey /etc/ssh/ssh_host_rsa_key
-HostKey /etc/ssh/ssh_host_dsa_key
+# HostKey /etc/ssh/ssh_host_dsa_key
 HostKey /etc/ssh/ssh_host_ecdsa_key
 HostKey /etc/ssh/ssh_host_ed25519_key
 #Privilege Separation is turned on for security


### PR DESCRIPTION
@tirumaraiselvan This PR fixes #78. But, while testing some other issue with certain parameters in `sshd_config` being deprecated has appeared. Please check once before merging.

The following lines appear continuously with different port numbers in the logs for gitkubed:
```
rexec line 19: Deprecated option KeyRegenerationInterval
rexec line 20: Deprecated option ServerKeyBits
rexec line 31: Deprecated option RSAAuthentication
rexec line 38: Deprecated option RhostsRSAAuthentication
Could not load host key: /etc/ssh/ssh_host_dsa_key
Did not receive identification string from 10.1.0.1 port 43146
```