### PR TITLE
refactor: Utilize kubernetes.Interface instead of *kubernetes.ClientSet

### DIFF
--- a/pkg/cmd/gitkube.go
+++ b/pkg/cmd/gitkube.go
@@ -78,7 +78,7 @@ func Execute() error {
 type Context struct {
 	KubeContext            string
 	Namespace              string
-	KubeClientSet          *kubernetes.Clientset
+	KubeClientSet          kubernetes.Interface
 	GitkubeClientSet       *gitkubeCS.Clientset
 	APIExtensionsClientSet *apiextensionsclient.Clientset
 }

--- a/pkg/controller/common.go
+++ b/pkg/controller/common.go
@@ -18,7 +18,7 @@ import (
 
 // RestartDeployment takes a deployment and annotates the pod spec with current timestamp
 // This causes a fresh rollout of the deployment
-func RestartDeployment(kubeclientset *kubernetes.Clientset, deployment *v1beta1.Deployment) error {
+func RestartDeployment(kubeclientset kubernetes.Interface, deployment *v1beta1.Deployment) error {
 
 	timeannotation := fmt.Sprintf("%v", time.Now().Unix())
 
@@ -36,7 +36,7 @@ func RestartDeployment(kubeclientset *kubernetes.Clientset, deployment *v1beta1.
 }
 
 // CreateGitkubeConf takes a list of remotes, reshapes it and marshals it into a string
-func CreateGitkubeConf(kubeclientset *kubernetes.Clientset, remotelister listers.RemoteLister) string {
+func CreateGitkubeConf(kubeclientset kubernetes.Interface, remotelister listers.RemoteLister) string {
 	remotes, err := remotelister.List(labels.Everything())
 	if err != nil {
 		//handle error
@@ -58,7 +58,7 @@ func CreateGitkubeConf(kubeclientset *kubernetes.Clientset, remotelister listers
 }
 
 // CreateRemoteJson takes a remote and reshapes it
-func CreateRemoteJson(kubeclientset *kubernetes.Clientset, remote *v1alpha1.Remote) interface{} {
+func CreateRemoteJson(kubeclientset kubernetes.Interface, remote *v1alpha1.Remote) interface{} {
 	remoteMap := make(map[string]interface{})
 	deploymentsMap := make(map[string]interface{})
 
@@ -84,7 +84,7 @@ func CreateRemoteJson(kubeclientset *kubernetes.Clientset, remote *v1alpha1.Remo
 }
 
 // createRegistryJson takes a remote and returns a reshaped map of its registry
-func createRegistryJson(kubeclientset *kubernetes.Clientset, remote *v1alpha1.Remote) interface{} {
+func createRegistryJson(kubeclientset kubernetes.Interface, remote *v1alpha1.Remote) interface{} {
 	registry := remote.Spec.Registry
 	registryMap := make(map[string]interface{})
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -58,7 +58,7 @@ func SetGitkubeNamespace(ns string) {
 }
 
 type GitController struct {
-	kubeclientset *kubernetes.Clientset
+	kubeclientset kubernetes.Interface
 
 	configmapsLister listercorev1.ConfigMapLister
 	configmapsSynced cache.InformerSynced
@@ -73,7 +73,7 @@ type GitController struct {
 
 // NewController returns a GitController
 func NewController(
-	kubeclientset *kubernetes.Clientset,
+	kubeclientset kubernetes.Interface,
 	clientset *clientset.Clientset,
 	kubeInformerFactory kubeinformers.SharedInformerFactory,
 	informerFactory informers.SharedInformerFactory) *GitController {

--- a/pkg/controller/util/service.go
+++ b/pkg/controller/util/service.go
@@ -9,7 +9,7 @@ import (
 
 // GetExternalIP gets the name or IP of (gitkubed) service
 // Returns error for unsupported Service types
-func GetExternalIP(kubeclientset *kubernetes.Clientset, service *corev1.Service) (string, error) {
+func GetExternalIP(kubeclientset kubernetes.Interface, service *corev1.Service) (string, error) {
 	switch service.Spec.Type {
 	case corev1.ServiceTypeClusterIP:
 		return "", fmt.Errorf("gitkube service type %s cannot be accessed from outside cluster. If this was intended, add remote manually",


### PR DESCRIPTION
Using concrete object instead of an interface makes code untestable.
This PR addresses the issue by changing funcs/methods to accept
interface instead of concrete object of kubernetes client set.

Signed-off-by: princerachit <prince.rachit@mayadata.io>