### PR TITLE
Enable multi-staged builds

### DIFF
--- a/build/gitkubed/Dockerfile
+++ b/build/gitkubed/Dockerfile
@@ -4,10 +4,10 @@ MAINTAINER tiru@hasura.io
 # Install openssh server
 RUN apt-get update \
  && apt-get install -y upx-ucl binutils curl openssh-server git jq \
- && curl -o /tmp/docker-17.05 'https://download.docker.com/linux/static/stable/x86_64/docker-17.06.0-ce.tgz' \
- && tar -xf /tmp/docker-17.05 -C /tmp \
+ && curl -o /tmp/docker-18.06 'https://download.docker.com/linux/static/stable/x86_64/docker-18.06.1-ce.tgz' \
+ && tar -xf /tmp/docker-18.06 -C /tmp \
  && mv /tmp/docker/docker /bin/docker \
- && rm -rf /tmp/docker-17.05 /tmp/docker \
+ && rm -rf /tmp/docker-18.06 /tmp/docker \
  && strip --strip-unneeded /bin/docker \
  && chmod a+x /bin/docker \
  && upx /bin/docker \

--- a/build/gitkubed/Dockerfile
+++ b/build/gitkubed/Dockerfile
@@ -4,10 +4,10 @@ MAINTAINER tiru@hasura.io
 # Install openssh server
 RUN apt-get update \
  && apt-get install -y upx-ucl binutils curl openssh-server git jq \
- && curl -o /tmp/docker-1.12 'https://get.docker.com/builds/Linux/x86_64/docker-1.12.6.tgz' \
- && tar -xf /tmp/docker-1.12 -C /tmp \
+ && curl -o /tmp/docker-17.05 'https://get.docker.com/builds/Linux/x86_64/docker-17.05.0-ce.tgz' \
+ && tar -xf /tmp/docker-17.05 -C /tmp \
  && mv /tmp/docker/docker /bin/docker \
- && rm -rf /tmp/docker-1.12 /tmp/docker \
+ && rm -rf /tmp/docker-17.05 /tmp/docker \
  && strip --strip-unneeded /bin/docker \
  && chmod a+x /bin/docker \
  && upx /bin/docker \

--- a/build/gitkubed/Dockerfile
+++ b/build/gitkubed/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER tiru@hasura.io
 # Install openssh server
 RUN apt-get update \
  && apt-get install -y upx-ucl binutils curl openssh-server git jq \
- && curl -o /tmp/docker-17.05 'https://get.docker.com/builds/Linux/x86_64/docker-17.05.0-ce.tgz' \
+ && curl -o /tmp/docker-17.05 'https://download.docker.com/linux/static/stable/x86_64/docker-17.06.0-ce.tgz' \
  && tar -xf /tmp/docker-17.05 -C /tmp \
  && mv /tmp/docker/docker /bin/docker \
  && rm -rf /tmp/docker-17.05 /tmp/docker \


### PR DESCRIPTION
Fixes #92: Multi-staged builds

To allow multi-staged builds, Docker 17.05 is required or higher is required on the daemon and the client. Documentation for Docker can be found [here](https://docs.docker.com/develop/develop-images/multistage-build/#before-multi-stage-builds).