### PR TITLE
Updated installation guide for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,11 @@ kubectl --namespace kube-system expose deployment gitkubed --type=LoadBalancer -
    ``` bash
    curl https://raw.githubusercontent.com/hasura/gitkube/master/gimme.sh | bash
    ```
-   - Windows: download the latest [release](https://github.com/hasura/gitkube/releases) and add it to your `PATH`.
+   - Windows (using [scoop](https://scoop.sh))
+   ```bat
+   scoop gitkube
+   ```
+   Or download the latest [release](https://github.com/hasura/gitkube/releases) and add it to your `PATH`.
 
 2. Use Gitkube CLI to install Gitkube on the cluster:
    ```bash


### PR DESCRIPTION
Add option to install `gitkube` binary using [scoop](https://scoop.sh). See lukesampson/scoop#3055.