### PR TITLE
silence 'Did not receive identification string from...' messages from SSHD/gikubed

### DIFF
--- a/build/gitkubed/sshd_config
+++ b/build/gitkubed/sshd_config
@@ -17,7 +17,7 @@ UsePrivilegeSeparation yes
 
 # Logging
 SyslogFacility AUTH
-LogLevel INFO
+LogLevel ERROR
 
 # Authentication:
 LoginGraceTime 120


### PR DESCRIPTION
With current SSHD configuration, gitkubed deployement readynessProbe on port 22 is throwing dozens of logs message like `Did not receive identification string from 10.93.50.85 port 5510` (every 2 seconds).

This tiny PR set SSH log level to ERROR instead of INFO fixing logs verbosity.